### PR TITLE
Obtain a required cookie when initializing Client; cache more eggs on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+/.eggs/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 cache:
   directories:
     - $HOME/.cache/pip
+    - .eggs
 install:
   - pip install .
   - pip install coveralls

--- a/openprocurement_client/client.py
+++ b/openprocurement_client/client.py
@@ -45,6 +45,10 @@ class Client(Resource):
         self.prefix_path = '/api/{}/tenders'.format(api_version)
         self.params = {"mode": "_all_"}
         self.headers = {"Content-Type": "application/json"}
+        # To perform some operations (e.g. create a tender)
+        # we first need to obtain a cookie. For that reason,
+        # here we send a HEAD request to a neutral URL.
+        self.head('/api/{}/spore'.format(api_version))
 
     def request(self, method, path=None, payload=None, headers=None,
                 params_dict=None, **params):


### PR DESCRIPTION
Having a cookie is mandatory for some operations since yesterday. This PR handles that requirement.
