### PR TITLE
Fix bug with different form of response header

### DIFF
--- a/openprocurement_client/client.py
+++ b/openprocurement_client/client.py
@@ -334,7 +334,7 @@ class TendersClient(APIBaseClient):
             if response_obj.status_int == 200:
                 return response_obj.body_string(), \
                     response_obj.headers['Content-Disposition'] \
-                    .split(";")[1].split('"')[1]
+                    .split("; filename=")[1].strip('"')
         raise InvalidResponse
 
     def extract_credentials(self, id):


### PR DESCRIPTION
Amazon DS returns http response with two different formats of
Content-Disposition header. Both formats must be supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.client.python/42)
<!-- Reviewable:end -->
