### PR TITLE
Add retry decorators

### DIFF
--- a/openprocurement_client/clients.py
+++ b/openprocurement_client/clients.py
@@ -9,6 +9,7 @@ from simplejson import loads
 from retrying import retry
 from munch import munchify
 
+from .exceptions import RequestFailed
 from openprocurement_client.resources.document_service import \
     DocumentServiceClient
 
@@ -77,6 +78,10 @@ class APIBaseClient(APITemplateClient):
             return munchify(loads(response_item.text))
         raise InvalidResponse(response_item)
 
+    @retry(wait_exponential_multiplier=200,
+           wait_exponential_max=1200,
+           stop_max_delay=45000,
+           retry_on_exception=lambda exc: isinstance(exc, RequestFailed))
     def _get_resource_item(self, url, headers=None):
         _headers = self.headers.copy()
         _headers.update(headers or {})
@@ -102,6 +107,10 @@ class APIBaseClient(APITemplateClient):
 
         raise InvalidResponse(response)
 
+    @retry(wait_exponential_multiplier=200,
+           wait_exponential_max=1200,
+           stop_max_delay=45000,
+           retry_on_exception=lambda exc: isinstance(exc, RequestFailed))
     def _patch_resource_item(self, url, payload, headers=None):
         _headers = self.headers.copy()
         _headers.update(headers or {})

--- a/openprocurement_client/clients.py
+++ b/openprocurement_client/clients.py
@@ -9,7 +9,6 @@ from simplejson import loads
 from retrying import retry
 from munch import munchify
 
-from .exceptions import RequestFailed
 from openprocurement_client.resources.document_service import \
     DocumentServiceClient
 
@@ -78,10 +77,6 @@ class APIBaseClient(APITemplateClient):
             return munchify(loads(response_item.text))
         raise InvalidResponse(response_item)
 
-    @retry(wait_exponential_multiplier=200,
-           wait_exponential_max=1200,
-           stop_max_delay=45000,
-           retry_on_exception=lambda exc: isinstance(exc, RequestFailed))
     def _get_resource_item(self, url, headers=None):
         _headers = self.headers.copy()
         _headers.update(headers or {})
@@ -107,10 +102,6 @@ class APIBaseClient(APITemplateClient):
 
         raise InvalidResponse(response)
 
-    @retry(wait_exponential_multiplier=200,
-           wait_exponential_max=1200,
-           stop_max_delay=45000,
-           retry_on_exception=lambda exc: isinstance(exc, RequestFailed))
     def _patch_resource_item(self, url, payload, headers=None):
         _headers = self.headers.copy()
         _headers.update(headers or {})

--- a/openprocurement_client/resources/assets.py
+++ b/openprocurement_client/resources/assets.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+from retrying import retry
+
 from openprocurement_client.clients import APIResourceClient
 from openprocurement_client.constants import ASSETS
+from openprocurement_client.exceptions import RequestFailed
 
 
 class AssetsClient(APIResourceClient):
@@ -12,6 +15,18 @@ class AssetsClient(APIResourceClient):
         super(AssetsClient, self).__init__(resource=self.resource, *args,
                                            **kwargs)
 
-    get_asset = APIResourceClient.get_resource_item
-
     get_assets = APIResourceClient.get_resource_items
+
+    @retry(wait_exponential_multiplier=200,
+           wait_exponential_max=1200,
+           stop_max_delay=45000,
+           retry_on_exception=lambda exc: isinstance(exc, RequestFailed))
+    def patch_asset(self, asset_id, patch_data):
+        return self.patch_resource_item(asset_id, patch_data)
+
+    @retry(wait_exponential_multiplier=200,
+           wait_exponential_max=1200,
+           stop_max_delay=45000,
+           retry_on_exception=lambda exc: isinstance(exc, RequestFailed))
+    def get_asset(self, asset_id):
+        return self.get_resource_item(asset_id)

--- a/openprocurement_client/resources/lots.py
+++ b/openprocurement_client/resources/lots.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+from retrying import retry
+
 from openprocurement_client.clients import APIResourceClient
 from openprocurement_client.constants import LOTS
+from openprocurement_client.exceptions import RequestFailed
 
 
 class LotsClient(APIResourceClient):
@@ -12,6 +15,18 @@ class LotsClient(APIResourceClient):
         super(LotsClient, self).__init__(resource=self.resource, *args,
                                          **kwargs)
 
-    get_lot = APIResourceClient.get_resource_item
-
     get_lots = APIResourceClient.get_resource_items
+
+    @retry(wait_exponential_multiplier=200,
+           wait_exponential_max=1200,
+           stop_max_delay=45000,
+           retry_on_exception=lambda exc: isinstance(exc, RequestFailed))
+    def patch_lot(self, lot_id, patch_data):
+        return self.patch_resource_item(lot_id, patch_data)
+
+    @retry(wait_exponential_multiplier=200,
+           wait_exponential_max=1200,
+           stop_max_delay=45000,
+           retry_on_exception=lambda exc: isinstance(exc, RequestFailed))
+    def get_lot(self, lot_id):
+        return self.get_resource_item(lot_id)

--- a/openprocurement_client/tests/test_registry_client.py
+++ b/openprocurement_client/tests/test_registry_client.py
@@ -96,11 +96,21 @@ class AssetsRegistryTestCase(BaseTestClass):
         asset = self.client.get_asset(TEST_ASSET_KEYS.asset_id)
         self.assertEqual(asset, self.asset)
 
-    def test_patch_asset(self):
+    def test_patch_resource_item(self):
         setup_routing(self.app, routes=["asset_patch"])
         asset_id = self.asset.data.id
         patch_data = {'data': {'description': 'test_patch_asset'}}
         patched_asset = self.client.patch_resource_item(asset_id,
+                                                        patch_data)
+        self.assertEqual(patched_asset.data.id, self.asset.data.id)
+        self.assertEqual(patched_asset.data.description,
+                         patch_data['data']['description'])
+
+    def test_patch_asset(self):
+        setup_routing(self.app, routes=["asset_patch"])
+        asset_id = self.asset.data.id
+        patch_data = {'data': {'description': 'test_patch_asset'}}
+        patched_asset = self.client.patch_asset(asset_id,
                                                         patch_data)
         self.assertEqual(patched_asset.data.id, self.asset.data.id)
         self.assertEqual(patched_asset.data.description,
@@ -136,11 +146,20 @@ class LotsRegistryTestCase(BaseTestClass):
         lot = self.client.get_lot(TEST_LOT_KEYS.lot_id)
         self.assertEqual(lot, self.lot)
 
-    def test_patch_lot(self):
+    def test_patch_resource_item(self):
         setup_routing(self.app, routes=["lot_patch"])
         lot_id = self.lot.data.id
         patch_data = {'data': {'description': 'test_patch_lot'}}
         patched_lot = self.client.patch_resource_item(lot_id, patch_data)
+        self.assertEqual(patched_lot.data.id, lot_id)
+        self.assertEqual(patched_lot.data.description,
+                         patch_data['data']['description'])
+
+    def test_patch_lot(self):
+        setup_routing(self.app, routes=["lot_patch"])
+        lot_id = self.lot.data.id
+        patch_data = {'data': {'description': 'test_patch_lot'}}
+        patched_lot = self.client.patch_lot(lot_id, patch_data)
         self.assertEqual(patched_lot.data.id, lot_id)
         self.assertEqual(patched_lot.data.description,
                          patch_data['data']['description'])


### PR DESCRIPTION
Add retry decorator to methods '_get_resource_item' and
'_patch_resource_item', which will be trying to repeat
request several times in case RequestFailed exception was raised

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.client.python/78)
<!-- Reviewable:end -->
